### PR TITLE
Fix multiple tests convenience doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The goal is to write the test, write the model, and then run the test (with “d
 
 ### Convenience features
 
-- You can define multiple tests in the same file using UNION [here](https://github.com/EqualExperts/dbt-unit-testing/blob/master/integration-tests/tests/unit/transform/covid_19_cases_per_day.sql).
+- You can define multiple tests in the same file using `UNION ALL` [here](data-models/tests/unit/transform/covid_19_cases_per_day.sql).
 - When mocking a ref or a model you just need to define the columns that you will test.
 
 #### Test Feedback


### PR DESCRIPTION
The example file link where multiple tests were defined in the same test
was pointing to an invalid target, that is now been fixed.

The sample code uses `UNION ALL` instead of `UNION` where multiple cases
are defined. The doc has been updated to use `UNION ALL` and the
keywords have been formatted as code rather than just uppercased.
