### PR TITLE
Remove need of Dbt run before running unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The goal is to write the test, write the model, and then run the test (with “d
 
 - Use fake inputs on any model or ref
 - Define fake inputs with sql
+- The tests run isolated inside a CTE without Db dependencies.
 - Focus the test on what’s important
 - Provide fast and valuable feedback
 - Write more than one test on a dbt test file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,4 +15,7 @@ services:
   postgres:
     image: postgres
     environment:
-      - POSTGRES_PASSWORD=mysecretpass
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - "5432:5432"

--- a/integration-tests/models/mock-staging-tables/covid19_country_stg.sql
+++ b/integration-tests/models/mock-staging-tables/covid19_country_stg.sql
@@ -1,7 +1,0 @@
-{{ config(materialized='table')}}
-with val as (
-select 
-'' as country_id,
-'' country_name
-)
-select * from val where country_name = 'test'

--- a/integration-tests/models/mock-staging-tables/covid19_stg.sql
+++ b/integration-tests/models/mock-staging-tables/covid19_stg.sql
@@ -1,7 +1,0 @@
-{{ config(materialized='table')}}
-with val as (
-select cast('2020-01-01' as Date) as day,
-'' as country_id,
-'{}' as payload
-)
-select * from val where country_id = 'test'

--- a/integration-tests/models/staging/sources.yml
+++ b/integration-tests/models/staging/sources.yml
@@ -4,4 +4,11 @@ sources:
   - name: dbt_unit_testing
     tables:
       - name: covid19_stg
+        columns:
+          - name: day
+          - name: country_id
+          - name: payload
       - name: covid19_country_stg
+        columns:
+          - name: country_id
+          - name: country_name

--- a/macros/test_helpers.sql
+++ b/macros/test_helpers.sql
@@ -19,10 +19,12 @@
   {% endif %}
 {% endmacro %}
 
-{% macro extract_columns_difference(query1, query2) %}
-  {% set cl1 = dbt_unit_testing.extract_columns_list(query1) %}
+{% macro extract_columns_difference_as_nulls(columns, query2) %}
   {% set cl2 = dbt_unit_testing.extract_columns_list(query2) %}
-  {% do return (cl1 | reject('in', cl2) | join(',')) %}
+  {% set columns = columns | list | reject('in', cl2) %}
+  {%- for column in columns -%}
+    null as {{column}},
+  {%- endfor -%}
 {% endmacro %}
 
 {% macro sql_encode(s) %}

--- a/run_test.sh
+++ b/run_test.sh
@@ -18,6 +18,4 @@ if [[ ! -e ~/.dbt/profiles.yml ]]; then
 fi
 
 dbt deps --target $1
-dbt run --target $1 --models mock-staging-tables
-dbt run --target $1 --models transform product
 dbt test --target $1 --models tag:unit-test


### PR DESCRIPTION
With this PR, we can remove the underlying database schema dependency from the tests.
The test development is quicker and improves developers' test/develop workflow.
The only dependency to run the unit tests is to have a connection to a database, so the unit tests use the SQL engine.

