### PR TITLE
Demo showing that CTEs not needed for query are being included, increasing query complexity

### DIFF
--- a/integration-tests/models/product/graph_a.sql
+++ b/integration-tests/models/product/graph_a.sql
@@ -1,0 +1,1 @@
+select 'a' as origin

--- a/integration-tests/models/product/graph_b.sql
+++ b/integration-tests/models/product/graph_b.sql
@@ -1,0 +1,1 @@
+select 'b' as origin

--- a/integration-tests/models/product/graph_c.sql
+++ b/integration-tests/models/product/graph_c.sql
@@ -1,0 +1,3 @@
+select origin from {{ dbt_unit_testing.ref('graph_b') }}
+union all
+select origin from {{ dbt_unit_testing.ref('graph_a') }}

--- a/integration-tests/models/product/graph_d.sql
+++ b/integration-tests/models/product/graph_d.sql
@@ -1,0 +1,1 @@
+select upper(origin) as origin from {{ dbt_unit_testing.ref('graph_c') }}

--- a/integration-tests/tests/unit/product/graph_mock_test.sql
+++ b/integration-tests/tests/unit/product/graph_mock_test.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        tags=['unit-test']
+    )
+}}
+
+{% call dbt_unit_testing.test ('graph_d') %}
+  {% call dbt_unit_testing.mock_ref('graph_c') %}
+    select 'x' as origin
+    union all
+    select 'y' as origin
+  {% endcall %}
+
+  {% call dbt_unit_testing.expect() %}
+    select 'X' as origin
+    union all
+    select 'Y' as origin
+  {% endcall %}
+{% endcall %}


### PR DESCRIPTION
I'm running into trouble getting dbt-unit-testing to work on bigquery.  I'm getting the error
`Resources exceeded during query execution: Not enough resources for query planning - too many subqueries or query is too complex`.
When I read the compiled SQL, I see that it's including CTEs that are upstream from the models that
need to be mocked.  I think it's all these unnecessary CTEs that are causing the issue.

Here's an example of a model graph that demonstrates the problem.  Model `a` and `b` are independent.
Model `c` is dependent on `a` and `b`.  Model `d` is dependent on model `c`.
```
a -> c -> d
b ---^
```

I want to write a unit test for model `d` and mock out model `c`.  Models `a` and `b` shouldn't be needed.  However,
the compiled SQL shows that they are included:
```
    with
-- NOTE: graph_c is mocked out properly here
      graph_c as (select * from (
    select 'x' as origin
    union all
    select 'y' as origin
  ) as graph_c_tmp_1
      ),

    expectations as (select "origin", count(*) as count from (
    select 'X' as origin
    union all
    select 'Y' as origin
  ) as s group by "origin"),

    actual as (select "origin", count(*) as count from ( with
-- NOTE: graph_a and graph_b are included here, but not referenced anywhere else
          graph_b as (select 'b' as origin),
          graph_a as (select 'a' as origin)
      select * from (select upper(origin) as origin from graph_c) as tmp ) as s group by "origin"),

    extra_entries as (
    select '+' as diff, count, "origin" from actual

    except

    select '+' as diff, count, "origin" from expectations),

    missing_entries as (
    select '-' as diff, count, "origin" from expectations

    except

    select '-' as diff, count, "origin" from actual)

    select * from extra_entries
    UNION ALL
    select * from missing_entries

```