### PR TITLE
Simplify workflow trigger to run on pull request target.

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -4,17 +4,12 @@ on:
   push:
     branches: [master]
   pull_request_target:
-    types: [opened, edited]
 
   workflow_dispatch:
 
 jobs:
   integration-tests-snowflake:
     runs-on: ubuntu-latest
-    if: |
-      github.event.review.state == 'approved' ||
-      github.event_name == 'push' || 
-      github.event_name == 'workflow_dispatch'
     environment: test
     env:
       SNOWFLAKE_TEST_ACCOUNT: ${{ secrets.SNOWFLAKE_TEST_ACCOUNT }}
@@ -31,10 +26,6 @@ jobs:
 
   integration-tests-bigquery:
     runs-on: ubuntu-latest
-    if: |
-      github.event.review.state == 'approved' ||
-      github.event_name == 'push' || 
-      github.event_name == 'workflow_dispatch'
     environment: test
 
     steps:
@@ -54,10 +45,6 @@ jobs:
 
   integration-tests-postgres:
     runs-on: ubuntu-latest
-    if: |
-      github.event.review.state == 'approved' ||
-      github.event_name == 'push' || 
-      github.event_name == 'workflow_dispatch'
     environment: test
 
     services:


### PR DESCRIPTION
Since we forbid the workflows to run automatically when the PRs are from external contributors, we have the ability to check the code for malicious behaviours, before running the Workflow. 