### PR TITLE
Reproduce bq complexity

### DIFF
--- a/integration-tests/models/complex/base_crd.sql
+++ b/integration-tests/models/complex/base_crd.sql
@@ -1,0 +1,11 @@
+select
+  *
+from
+  {{ dbt_unit_testing.source('dbt_unit_testing', 'crd') }}
+where
+  true
+qualify
+  -- Remove duplicated signals
+  row_number() over (
+    partition by device_serial_number, timestamp order by timestamp desc
+  ) = 1

--- a/integration-tests/models/complex/base_cyc_a.sql
+++ b/integration-tests/models/complex/base_cyc_a.sql
@@ -1,0 +1,11 @@
+select
+  *
+from
+  {{ dbt_unit_testing.source('dbt_unit_testing', 'cyc_a') }}
+where
+  true
+qualify
+  -- Remove duplicated signals
+  row_number() over (
+    partition by device_serial_number, timestamp order by timestamp desc
+  ) = 1

--- a/integration-tests/models/complex/base_cyc_b.sql
+++ b/integration-tests/models/complex/base_cyc_b.sql
@@ -1,0 +1,11 @@
+select
+  *
+from
+  {{ dbt_unit_testing.source('dbt_unit_testing', 'cyc_b') }}
+where
+  true
+qualify
+  -- Remove duplicated signals
+  row_number() over (
+    partition by device_serial_number, timestamp order by timestamp desc
+  ) = 1

--- a/integration-tests/models/complex/base_minutes.sql
+++ b/integration-tests/models/complex/base_minutes.sql
@@ -1,0 +1,25 @@
+WITH spine AS (
+  {{
+    dbt_utils.date_spine(
+      datepart="minute",
+      start_date="datetime '2020-01-01 00:00:00'",
+      end_date="current_datetime() + interval 1 week"
+     )
+  }}
+),
+
+final as (
+  select
+    timestamp(date_minute, 'UTC') as minute_at,
+    -- The first minute of an interval is associated with the previous bin
+    -- because signals are typically recorded on the 15 minute mark and correspond to the previous 15 min
+    {% set bin_15m_start = "timestamp(date_minute, 'UTC') - interval 1 minute - interval mod(extract(minute from date_minute - interval 1 minute), 15) minute" %}
+    {{ bin_15m_start }} as bin_15m_start_at,
+    {{ bin_15m_start }} + interval 15 minute as bin_15m_end_at
+  from
+    spine
+  order by
+    date_minute
+)
+
+select * from final

--- a/integration-tests/models/complex/base_package.sql
+++ b/integration-tests/models/complex/base_package.sql
@@ -1,0 +1,11 @@
+select
+  *
+from
+  {{ dbt_unit_testing.source('dbt_unit_testing', 'package') }}
+where
+  true
+qualify
+  -- Remove duplicated signals
+  row_number() over (
+    partition by device_serial_number, timestamp order by timestamp desc
+  ) = 1

--- a/integration-tests/models/complex/base_site.sql
+++ b/integration-tests/models/complex/base_site.sql
@@ -1,0 +1,11 @@
+select
+  *
+from
+  {{ dbt_unit_testing.source('dbt_unit_testing', 'site') }}
+where
+  true
+qualify
+  -- Remove duplicated signals
+  row_number() over (
+    partition by device_serial_number, timestamp order by timestamp desc
+  ) = 1

--- a/integration-tests/models/complex/binned.sql
+++ b/integration-tests/models/complex/binned.sql
@@ -1,0 +1,64 @@
+with binned_signals as (
+  with signals as (
+    select
+      device_serial_number,
+      timestamp as signal_at,
+      date_trunc(timestamp, minute) as signal_minute_at,
+      energy
+    from
+      {{ dbt_unit_testing.ref('base_package') }}
+  ),
+
+  device_minutes as (
+    select * from {{ dbt_unit_testing.ref('stg_device_minutes') }}
+  ),
+
+  assign_bins as (
+    select
+      device_minutes.site_id,
+      device_minutes.device_serial_number,
+      device_minutes.bin_15m_start_at,
+      device_minutes.bin_15m_end_at,
+      signals.energy,
+      coalesce(signals.signal_at, device_minutes.minute_at) as signal_at
+    from
+      device_minutes
+    left join
+      signals
+    on
+      device_minutes.device_serial_number = signals.device_serial_number
+      and
+      device_minutes.minute_at = signals.signal_minute_at
+
+  ),
+
+  -- Yes, these are completely useless, but having them produces the error
+  just_another_query as (
+    select t1.*, 1 as d_energy
+    from assign_bins as t1
+    inner join assign_bins as t2
+    on
+      t1.device_serial_number = t2.device_serial_number
+      and
+      t1.signal_at = t2.signal_at
+  ),
+
+  just_another_query_2 as (
+    select t1.*, 1 as d_energy
+    from just_another_query as t1
+    inner join just_another_query as t2
+    on
+      t1.device_serial_number = t2.device_serial_number
+      and
+      t1.signal_at = t2.signal_at
+  )
+
+
+  select * from just_another_query_2
+),
+
+final as (
+  select * from binned_signals
+)
+
+select * from final

--- a/integration-tests/models/complex/sources.yml
+++ b/integration-tests/models/complex/sources.yml
@@ -1,0 +1,30 @@
+version: 2
+
+sources:
+  - name: dbt_unit_testing
+    tables:
+      - name: package
+        columns:
+          - name: device_serial_number
+          - name: timestamp
+          - name: energy
+      - name: cyc_a
+        columns:
+          - name: device_serial_number
+          - name: timestamp
+          - name: cyc_sig
+      - name: cyc_b
+        columns:
+          - name: device_serial_number
+          - name: timestamp
+          - name: cyc_sig
+      - name: crd
+        columns:
+          - name: device_serial_number
+          - name: timestamp
+          - name: sig
+      - name: site
+        columns:
+          - name: device_serial_number
+          - name: timestamp
+          - name: sig

--- a/integration-tests/models/complex/stg_device_minutes.sql
+++ b/integration-tests/models/complex/stg_device_minutes.sql
@@ -1,0 +1,26 @@
+with devices as (
+  select * from {{ dbt_unit_testing.ref('stg_devices') }}
+),
+
+base_minutes as (
+  select * from {{ dbt_unit_testing.ref('base_minutes') }}
+),
+
+final as (
+  select
+    devices.site_id,
+    devices.device_serial_number,
+    base_minutes.minute_at,
+    base_minutes.bin_15m_start_at,
+    base_minutes.bin_15m_end_at
+  from
+    devices
+  cross join
+    base_minutes
+  where
+    base_minutes.minute_at >= date_trunc(devices.min_timestamp_at, minute)
+    and
+    base_minutes.minute_at < date_trunc(devices.max_timestamp_at, minute)
+)
+
+select * from final

--- a/integration-tests/models/complex/stg_devices.sql
+++ b/integration-tests/models/complex/stg_devices.sql
@@ -1,0 +1,40 @@
+with all_signal_sources as (
+  select device_serial_number, timestamp from {{ dbt_unit_testing.ref('base_cyc_a') }}
+  union all
+  select device_serial_number, timestamp from {{ dbt_unit_testing.ref('base_cyc_b') }}
+  union all
+  select device_serial_number, timestamp from {{ dbt_unit_testing.ref('stg_grid') }}
+  union all
+  select device_serial_number, timestamp from {{ dbt_unit_testing.ref('base_package') }}
+),
+
+package_locations as (
+  select * from {{ dbt_unit_testing.ref('seed_device_site') }}
+),
+
+all_devices as (
+  select
+    device_serial_number,
+    min(timestamp) as min_timestamp_at,
+    max(timestamp) as max_timestamp_at
+  from
+    all_signal_sources
+  group by
+    1
+),
+
+final as (
+  select
+    coalesce(package_locations.site_id, all_devices.device_serial_number) as site_id,
+    all_devices.device_serial_number,
+    all_devices.min_timestamp_at,
+    all_devices.max_timestamp_at
+  from
+    all_devices
+  left join
+    package_locations
+  on
+    all_devices.device_serial_number = package_locations.device_serial_number
+)
+
+select * from final

--- a/integration-tests/models/complex/stg_grid.sql
+++ b/integration-tests/models/complex/stg_grid.sql
@@ -1,0 +1,3 @@
+select 'crd' as record_origin, device_serial_number, timestamp, sig from {{ dbt_unit_testing.ref('base_crd') }}
+union all
+select 'site' as record_origin, device_serial_number, timestamp, sig from {{ dbt_unit_testing.ref('base_site') }}

--- a/integration-tests/models/product/graph_a.sql
+++ b/integration-tests/models/product/graph_a.sql
@@ -1,0 +1,1 @@
+select 'a' as origin

--- a/integration-tests/models/product/graph_b.sql
+++ b/integration-tests/models/product/graph_b.sql
@@ -1,0 +1,1 @@
+select 'b' as origin

--- a/integration-tests/models/product/graph_c.sql
+++ b/integration-tests/models/product/graph_c.sql
@@ -1,0 +1,3 @@
+select origin from {{ dbt_unit_testing.ref('graph_b') }}
+union all
+select origin from {{ dbt_unit_testing.ref('graph_a') }}

--- a/integration-tests/models/product/graph_d.sql
+++ b/integration-tests/models/product/graph_d.sql
@@ -1,0 +1,1 @@
+select upper(origin) as origin from {{ dbt_unit_testing.ref('graph_c') }}

--- a/integration-tests/seeds/properties.yml
+++ b/integration-tests/seeds/properties.yml
@@ -5,3 +5,7 @@ seeds:
     config:
       column_types:
         value: numeric
+  - name: seed_device_site
+    config:
+      column_types:
+        value: string

--- a/integration-tests/seeds/seed_device_site.csv
+++ b/integration-tests/seeds/seed_device_site.csv
@@ -1,0 +1,2 @@
+device_serial_number,site_id
+x1,s1

--- a/integration-tests/tests/unit/complex/complex_binned_test.sql
+++ b/integration-tests/tests/unit/complex/complex_binned_test.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        tags=['unit-test']
+    )
+}}
+
+{% call dbt_unit_testing.test('binned', 'test complex query') %}
+  {% call dbt_unit_testing.mock_ref('base_package') %}
+    select 'X1' as device_serial_number, timestamp('2022-01-01 00:17:00') as timestamp, 1.0 as energy
+  {% endcall %}
+
+  {% call dbt_unit_testing.mock_ref('stg_device_minutes') %}
+    select 'X1' as device_serial_number, timestamp('2022-01-01 00:17:00') as minute_at, timestamp('2022-01-01 00:15:00') as bin_15m_start_at
+  {% endcall %}
+
+  {% call dbt_unit_testing.expect() %}
+    select 'X1' as device_serial_number, timestamp('2022-01-01 00:17:00') as bin_15m_start_at, 1.0 as energy
+  {% endcall %}
+{% endcall %}

--- a/integration-tests/tests/unit/product/graph_mock_test.sql
+++ b/integration-tests/tests/unit/product/graph_mock_test.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        tags=['unit-test']
+    )
+}}
+
+{% call dbt_unit_testing.test ('graph_d') %}
+  {% call dbt_unit_testing.mock_ref('graph_c') %}
+    select 'x' as origin
+    union all
+    select 'y' as origin
+  {% endcall %}
+
+  {% call dbt_unit_testing.expect() %}
+    select 'X' as origin
+    union all
+    select 'Y' as origin
+  {% endcall %}
+{% endcall %}


### PR DESCRIPTION
Related to #33 

This is a bit of a garbage model that does a lot of uneccessary things, but it's roughly based on a real situation where we're tyring to put various measurements from a bunch of different sources into 15 minute bins.  Once the sources and seeds are created in bigquery, the model will run.  However, the test against the `binned` model fails due to the following error:

```
Resources exceeded during query execution: Not enough resources for query planning - too many subqueries or query is too complex
```

Here is some SQL that can be run to create some dummy source tables in BQ:
```
create table dbt_unit_testing.package as (select 'y1' as device_serial_number, timestamp('2021-01-01 00:00:00') as timestamp, 1.0 as energy);
create table dbt_unit_testing.cyc_a as (select 'y1' as device_serial_number, timestamp('2021-01-01 00:00:00') as timestamp, 1.0 as cyc_sig);
create table dbt_unit_testing.cyc_b as (select 'y1' as device_serial_number, timestamp('2021-01-01 00:00:00') as timestamp, 1.0 as cyc_sig);
create table dbt_unit_testing.crd as (select 'y1' as device_serial_number, timestamp('2021-01-01 00:00:00') as timestamp, 1.0 as sig);
create table dbt_unit_testing.site as (select 'y1' as device_serial_number, timestamp('2021-01-01 00:00:00') as timestamp, 1.0 as sig);
```


