### PR TITLE
Fully qualify objects by adding {{node.database}} in sql_builders.sql

### DIFF
--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -69,15 +69,16 @@
 
 {% macro fake_model_sql(node) %}
   {% set source_relation = dbt_utils.get_relations_by_pattern(
+      database=node.database,
       schema_pattern=node.schema,
       table_pattern=node.name
   ) %}
   {% if source_relation | length > 0 %}
     {%- set source_sql -%}
-      select * from {{ node.schema }}.{{ node.name }} where false
+      select * from {{node.database}}.{{ node.schema }}.{{ node.name }} where false
     {%- endset -%}
     select {{ dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(source_sql)) }}
-    from {{ node.schema }}.{{ node.name }}
+    from {{node.database}}.{{ node.schema }}.{{ node.name }}
     where false
   {% else %}
     {% if node.columns %}
@@ -94,15 +95,16 @@
 
 {% macro fake_source_sql(node) %}
   {% set source_relation = dbt_utils.get_relations_by_pattern(
+      database=node.database,
       schema_pattern=node.schema,
       table_pattern=node.name
   ) %}
   {% if source_relation | length > 0 %}
     {%- set source_sql -%}
-      select * from {{ node.schema }}.{{ node.name }} where false
+      select * from {{node.database}}.{{ node.schema }}.{{ node.name }} where false
     {%- endset -%}
     select {{ dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(source_sql)) }}
-    from {{ node.schema }}.{{ node.name }}
+    from {{node.database}}.{{ node.schema }}.{{ node.name }}
     where false
   {% else %}
     {% if node.columns %}
@@ -119,15 +121,16 @@
 
 {% macro fake_seed_sql(node) %}
   {% set source_relation = dbt_utils.get_relations_by_pattern(
+      database=node.database,
       schema_pattern=node.schema,
       table_pattern=node.name
   ) %}
   {% if source_relation | length > 0 %}
     {%- set source_sql -%}
-      select * from {{ node.schema }}.{{ node.name }} where false
+      select * from {{node.database}}.{{ node.schema }}.{{ node.name }} where false
     {%- endset -%}
     select {{ dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(source_sql)) }}
-    from {{ node.schema }}.{{ node.name }}
+    from {{node.database}}.{{ node.schema }}.{{ node.name }}
     where false
   {% else %}
     {% if node.config and node.config.column_types %}


### PR DESCRIPTION
# Description
`dbt-unit-testing` assumes a single database should be used throughout the session. However, this raises issues when, for instance, the source data is located in another database than the one defined in the dbt profile. This is probably specific to Snowflake, where multiple databases are commonly used to separate source data from modeled data.

# Example
_profiles.yml_
```yaml
snowflake:
  target: ci
  outputs:
    ci:
      type: snowflake
      database: CI
      ...
```

_sources.yml_
```yaml
version: 2

sources:
  - name: product
    database: raw
    schema: product
    tables:
      - name: users
```

_tests.sql_
```sql
{{ config(tags=['unit-test']) }}

{% call dbt_unit_testing.test('stg_users',) %}
  {% call dbt_unit_testing.mock_source('product', 'users') %}
    ...
  {% endcall %}
  {% call dbt_unit_testing.expect() %}
   ...
  {% endcall %}

{% endcall %}
```

`dbt-unit-testing` will raise this error because it is unable to find `raw.product.users`:
```
19:25:11    Source users columns must be declared in sources.yml, or it must exist in database
19:25:11    
19:25:11    > in macro fake_source_sql (macros/sql_builders.sql)
19:25:11    > called by macro build_node_sql (macros/sql_builders.sql)
19:25:11    > called by macro mock_input (macros/tests.sql)
19:25:11    > called by macro mock_source (macros/tests.sql)
19:25:11    > called by macro test (macros/tests.sql)
19:25:11    > called by test test_stg_users (tests/tests.sql)
19:25:11    > called by test test_stg_users (tests/tests.sql)
```

This is because it looks for `users` in the same database as the one defined in `profiles.yml`, not the database defined in `sources.yml`, as shown by the compiled Snowflake query:
```sql
select distinct
            table_schema as "table_schema",
            table_name as "table_name",
            
            case table_type
                when 'BASE TABLE' then 'table'
                when 'EXTERNAL TABLE' then 'external'
                when 'MATERIALIZED VIEW' then 'materializedview'
                else lower(table_type)
            end as "table_type"

        from ci.information_schema.tables
        where table_schema ilike 'product'
        and table_name ilike 'users'
        and table_name not ilike ''
```

# Proposed Solution
This PR proposes to fully qualify objects in `sql_builders.sql` such that the `node.database` is also injected in the SQL queries. From the example above, this would yield the following query which solves the issue described above:
```sql
select distinct
            table_schema as "table_schema",
            table_name as "table_name",
            
            case table_type
                when 'BASE TABLE' then 'table'
                when 'EXTERNAL TABLE' then 'external'
                when 'MATERIALIZED VIEW' then 'materializedview'
                else lower(table_type)
            end as "table_type"

        from raw.information_schema.tables
        where table_schema ilike 'product'
        and table_name ilike 'users'
        and table_name not ilike ''
```