### PR TITLE
Quote table name

### DIFF
--- a/integration-tests/models/model-refers-model-with-dashes.sql
+++ b/integration-tests/models/model-refers-model-with-dashes.sql
@@ -1,1 +1,1 @@
-select * from {{ ref('model-with-dashes') }}
+select * from {{ dbt_unit_testing.ref('model-with-dashes') }}

--- a/integration-tests/models/model-refers-model-with-dashes.sql
+++ b/integration-tests/models/model-refers-model-with-dashes.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('model-with-dashes') }}

--- a/integration-tests/models/model-refers-source-with-dashes.sql
+++ b/integration-tests/models/model-refers-source-with-dashes.sql
@@ -1,0 +1,1 @@
+select * from {{ dbt_unit_testing.source('dbt_unit_testing', 'source-with-dashes') }}

--- a/integration-tests/models/model-with-dashes.sql
+++ b/integration-tests/models/model-with-dashes.sql
@@ -1,0 +1,1 @@
+select 1 as "example"

--- a/integration-tests/models/model-with-dashes.sql
+++ b/integration-tests/models/model-with-dashes.sql
@@ -1,1 +1,1 @@
-select 1 as "example"
+select 2 as example

--- a/integration-tests/models/model_refers_source_with_identifier.sql
+++ b/integration-tests/models/model_refers_source_with_identifier.sql
@@ -1,0 +1,1 @@
+select * from {{ dbt_unit_testing.source('dbt_unit_testing', 'sample_source_name') }}

--- a/integration-tests/models/setup-existing-source/sample_source_identifier.sql
+++ b/integration-tests/models/setup-existing-source/sample_source_identifier.sql
@@ -1,0 +1,2 @@
+--this source is used to test referring to a source with an identifier
+select 1 as example

--- a/integration-tests/models/sources/sources.yml
+++ b/integration-tests/models/sources/sources.yml
@@ -13,3 +13,5 @@ sources:
         columns:
           - name: example
             data_type: integer
+      - name: sample_source_name
+        identifier: sample_source_identifier

--- a/integration-tests/models/sources/sources.yml
+++ b/integration-tests/models/sources/sources.yml
@@ -9,3 +9,7 @@ sources:
             data_type: integer
           - name: source_b
       - name: sample_source_without_columns_declared
+      - name: source-with-dashes
+        columns:
+          - name: example
+            data_type: integer

--- a/integration-tests/tests/unit/bigquery/model-refers-model-with-dashes.sql
+++ b/integration-tests/tests/unit/bigquery/model-refers-model-with-dashes.sql
@@ -1,0 +1,14 @@
+{{
+    config(
+        tags=['unit-test', 'bigquery', 'snowflake', 'postgres']
+    )
+}}
+
+{% call dbt_unit_testing.test('model-refers-model-with-dashes', 'Can refer to model with dashes in name') %}
+  {% call dbt_unit_testing.mock_ref ('model-with-dashes') %}
+    select 1 as "example"
+  {% endcall %}
+  {% call dbt_unit_testing.expect() %}
+    select 1 as "example"
+  {% endcall %}
+{% endcall %}

--- a/integration-tests/tests/unit/model_refers_model_with_dashes.sql
+++ b/integration-tests/tests/unit/model_refers_model_with_dashes.sql
@@ -6,9 +6,9 @@
 
 {% call dbt_unit_testing.test('model-refers-model-with-dashes', 'Can refer to model with dashes in name') %}
   {% call dbt_unit_testing.mock_ref ('model-with-dashes') %}
-    select 1 as "example"
+    select 1 as example
   {% endcall %}
   {% call dbt_unit_testing.expect() %}
-    select 1 as "example"
+    select 1 as example
   {% endcall %}
 {% endcall %}

--- a/integration-tests/tests/unit/model_refers_source_with_dashes.sql
+++ b/integration-tests/tests/unit/model_refers_source_with_dashes.sql
@@ -1,0 +1,14 @@
+{{
+    config(
+        tags=['unit-test', 'bigquery', 'snowflake', 'postgres']
+    )
+}}
+
+{% call dbt_unit_testing.test('model-refers-source-with-dashes', 'Can refer to source with dashes in name') %}
+  {% call dbt_unit_testing.mock_source ('dbt_unit_testing', 'source-with-dashes') %}
+    select 1 as example
+  {% endcall %}
+  {% call dbt_unit_testing.expect() %}
+    select 1 as example
+  {% endcall %}
+{% endcall %}

--- a/integration-tests/tests/unit/model_refers_source_with_identifier.sql
+++ b/integration-tests/tests/unit/model_refers_source_with_identifier.sql
@@ -1,0 +1,14 @@
+{{
+    config(
+        tags=['unit-test', 'bigquery', 'snowflake', 'postgres']
+    )
+}}
+
+{% call dbt_unit_testing.test('model_refers_source_with_identifier', 'Can refer to source that has an identifier') %}
+  {% call dbt_unit_testing.mock_source ('dbt_unit_testing', 'sample_source_name') %}
+    select 1 as example
+  {% endcall %}
+  {% call dbt_unit_testing.expect() %}
+    select 1 as example
+  {% endcall %}
+{% endcall %}

--- a/macros/adapters.sql
+++ b/macros/adapters.sql
@@ -1,27 +1,27 @@
-{% macro quote_column_name(column_name) %}
-    {{ return(adapter.dispatch('quote_column_name','dbt_unit_testing')(column_name)) }}
+{% macro quote_identifier(identifier) %}
+    {{ return(adapter.dispatch('quote_identifier','dbt_unit_testing')(identifier)) }}
 {% endmacro %}
 
-{% macro default__quote_column_name(column_name) -%}
-    {% if column_name.startswith('"') %}
-      {{ return(column_name) }}
+{% macro default__quote_identifier(identifier) -%}
+    {% if identifier.startswith('"') %}
+      {{ return(identifier) }}
     {% else %}
-      {{ return('"' ~ column_name ~ '"') }}
+      {{ return('"' ~ identifier ~ '"') }}
     {% endif %}
 {%- endmacro %}
 
-{% macro bigquery__quote_column_name(column_name) %}
-    {% if column_name.startswith('`') %}
-      {{ return(column_name) }}
+{% macro bigquery__quote_identifier(identifier) %}
+    {% if identifier.startswith('`') %}
+      {{ return(identifier) }}
     {% else %}
-      {{ return('`' ~ column_name ~ '`') }}
+      {{ return('`' ~ identifier ~ '`') }}
     {% endif %}
 {% endmacro %}
 
-{% macro snowflake__quote_column_name(column_name) %}
-    {% if column_name.startswith('"') %}
-      {{ return(column_name) }}
+{% macro snowflake__quote_identifier(identifier) %}
+    {% if identifier.startswith('"') %}
+      {{ return(identifier) }}
     {% else %}
-      {{ return('"' ~ column_name | upper ~ '"') }}
+      {{ return('"' ~ identifier | upper ~ '"') }}
     {% endif %}
 {% endmacro %}

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -1,3 +1,7 @@
+{% macro node_to_sql(node) %}
+  {{ return(dbt_unit_testing.quote_column_name(node.database ~ '.' ~ node.schema ~ '.' ~ node.name))}}
+{% endmacro %}
+
 {% macro build_model_complete_sql(model_node, mocked_models, options) %}
   {% if execute %}
     {% set include_all_dependencies = options.get("include_all_dependencies", false) %}
@@ -75,10 +79,10 @@
   ) %}
   {% if source_relation | length > 0 %}
     {%- set source_sql -%}
-      select * from `{{node.database}}.{{ node.schema }}.{{ node.name }}` where false
+      select * from {{ dbt_unit_testing.node_to_sql(node) }} where false
     {%- endset -%}
     select {{ dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(source_sql)) }}
-    from `{{node.database}}.{{ node.schema }}.{{ node.name }}`
+    from {{ dbt_unit_testing.node_to_sql(node) }}
     where false
   {% else %}
     {% if node.columns %}
@@ -101,10 +105,10 @@
   ) %}
   {% if source_relation | length > 0 %}
     {%- set source_sql -%}
-      select * from `{{node.database}}.{{ node.schema }}.{{ node.name }}` where false
+      select * from {{ dbt_unit_testing.node_to_sql(node) }} where false
     {%- endset -%}
     select {{ dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(source_sql)) }}
-    from `{{node.database}}.{{ node.schema }}.{{ node.name }}`
+    from {{ dbt_unit_testing.node_to_sql(node) }}
     where false
   {% else %}
     {% if node.columns %}
@@ -127,10 +131,10 @@
   ) %}
   {% if source_relation | length > 0 %}
     {%- set source_sql -%}
-      select * from `{{node.database}}.{{ node.schema }}.{{ node.name }}` where false
+      select * from {{ dbt_unit_testing.node_to_sql(node) }} where false
     {%- endset -%}
     select {{ dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(source_sql)) }}
-    from `{{node.database}}.{{ node.schema }}.{{ node.name }}`
+    from {{ dbt_unit_testing.node_to_sql(node) }}
     where false
   {% else %}
     {% if node.config and node.config.column_types %}

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -1,5 +1,5 @@
 {% macro node_to_sql(node) %}
-  {{ return(dbt_unit_testing.quote_column_name(node.database ~ '.' ~ node.schema ~ '.' ~ node.name))}}
+  {{ return(dbt_unit_testing.quote_identifier(node.database ~ '.' ~ node.schema ~ '.' ~ node.name))}}
 {% endmacro %}
 
 {% macro build_model_complete_sql(model_node, mocked_models, options) %}
@@ -88,7 +88,7 @@
     {% if node.columns %}
       {% set columns = [] %}
       {% for c in node.columns.values() %}
-        {% do columns.append("cast(null as " ~ (c.data_type if c.data_type is not none else dbt_utils.type_string()) ~ ") as " ~ dbt_unit_testing.quote_column_name(c.name)) %}
+        {% do columns.append("cast(null as " ~ (c.data_type if c.data_type is not none else dbt_utils.type_string()) ~ ") as " ~ dbt_unit_testing.quote_identifier(c.name)) %}
       {% endfor %}
       select {{ columns | join (",") }}
     {% else %}
@@ -114,7 +114,7 @@
     {% if node.columns %}
       {% set columns = [] %}
       {% for c in node.columns.values() %}
-        {% do columns.append("cast(null as " ~ (c.data_type if c.data_type is not none else dbt_utils.type_string()) ~ ") as " ~ dbt_unit_testing.quote_column_name(c.name)) %}
+        {% do columns.append("cast(null as " ~ (c.data_type if c.data_type is not none else dbt_utils.type_string()) ~ ") as " ~ dbt_unit_testing.quote_identifier(c.name)) %}
       {% endfor %}
       select {{ columns | join (",") }}
     {% else %}
@@ -140,7 +140,7 @@
     {% if node.config and node.config.column_types %}
       {% set columns = [] %}
       {% for c in node.config.column_types.keys() %}
-        {% do columns.append("cast(null as " ~ (node.config.column_types[c] if node.config.column_types[c] is not none else dbt_utils.type_string()) ~ ") as " ~ dbt_unit_testing.quote_column_name(c)) %}
+        {% do columns.append("cast(null as " ~ (node.config.column_types[c] if node.config.column_types[c] is not none else dbt_utils.type_string()) ~ ") as " ~ dbt_unit_testing.quote_identifier(c)) %}
       {% endfor %}
       select {{ columns | join (",") }}
     {% else %}

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -1,5 +1,5 @@
 {% macro node_to_sql(node) %}
-  {{ return(dbt_unit_testing.quote_identifier(node.database ~ '.' ~ node.schema ~ '.' ~ node.name))}}
+  {{ return(dbt_unit_testing.quote_identifier(node.database) ~ '.' ~ dbt_unit_testing.quote_identifier(node.schema) ~ '.' ~ dbt_unit_testing.quote_identifier(node.name))}}
 {% endmacro %}
 
 {% macro build_model_complete_sql(model_node, mocked_models, options) %}
@@ -17,7 +17,7 @@
       {% else %}
         {% set sql = dbt_unit_testing.build_node_sql(node, options) %}
       {% endif %}
-      {% set cte = node.name ~ " as (" ~ sql ~ ")" %}
+      {% set cte = dbt_unit_testing.quote_identifier(node.name) ~ " as (" ~ sql ~ ")" %}
       {% set cte_dependencies = cte_dependencies.append(cte) %}
     {%- endfor -%}
 

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -1,5 +1,13 @@
-{% macro node_to_sql(node) %}
-  {{ return(dbt_unit_testing.quote_identifier(node.database) ~ '.' ~ dbt_unit_testing.quote_identifier(node.schema) ~ '.' ~ dbt_unit_testing.quote_identifier(node.name))}}
+{% macro node_to_sql(database, schema, identifier) %}
+  {{ return(dbt_unit_testing.quote_identifier(database) ~ '.' ~ dbt_unit_testing.quote_identifier(schema) ~ '.' ~ dbt_unit_testing.quote_identifier(identifier))}}
+{% endmacro %}
+
+{% macro source_node_to_sql(node) %}
+  {{ return(dbt_unit_testing.node_to_sql(node.database, node.schema, node.identifier))}}
+{% endmacro %}
+
+{% macro model_node_to_sql(node) %}
+  {{ return(dbt_unit_testing.node_to_sql(node.database, node.schema, node.name))}}
 {% endmacro %}
 
 {% macro build_model_complete_sql(model_node, mocked_models, options) %}
@@ -79,10 +87,10 @@
   ) %}
   {% if source_relation | length > 0 %}
     {%- set source_sql -%}
-      select * from {{ dbt_unit_testing.node_to_sql(node) }} where false
+      select * from {{ dbt_unit_testing.model_node_to_sql(node) }} where false
     {%- endset -%}
     select {{ dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(source_sql)) }}
-    from {{ dbt_unit_testing.node_to_sql(node) }}
+    from {{ dbt_unit_testing.model_node_to_sql(node) }}
     where false
   {% else %}
     {% if node.columns %}
@@ -101,14 +109,14 @@
   {% set source_relation = dbt_utils.get_relations_by_pattern(
       database=node.database,
       schema_pattern=node.schema,
-      table_pattern=node.name
+      table_pattern=node.identifier
   ) %}
   {% if source_relation | length > 0 %}
     {%- set source_sql -%}
-      select * from {{ dbt_unit_testing.node_to_sql(node) }} where false
+      select * from {{ dbt_unit_testing.source_node_to_sql(node) }} where false
     {%- endset -%}
     select {{ dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(source_sql)) }}
-    from {{ dbt_unit_testing.node_to_sql(node) }}
+    from {{ dbt_unit_testing.source_node_to_sql(node) }}
     where false
   {% else %}
     {% if node.columns %}
@@ -131,10 +139,10 @@
   ) %}
   {% if source_relation | length > 0 %}
     {%- set source_sql -%}
-      select * from {{ dbt_unit_testing.node_to_sql(node) }} where false
+      select * from {{ dbt_unit_testing.model_node_to_sql(node) }} where false
     {%- endset -%}
     select {{ dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(source_sql)) }}
-    from {{ dbt_unit_testing.node_to_sql(node) }}
+    from {{ dbt_unit_testing.model_node_to_sql(node) }}
     where false
   {% else %}
     {% if node.config and node.config.column_types %}

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -75,10 +75,10 @@
   ) %}
   {% if source_relation | length > 0 %}
     {%- set source_sql -%}
-      select * from {{node.database}}.{{ node.schema }}.{{ node.name }} where false
+      select * from `{{node.database}}.{{ node.schema }}.{{ node.name }}` where false
     {%- endset -%}
     select {{ dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(source_sql)) }}
-    from {{node.database}}.{{ node.schema }}.{{ node.name }}
+    from `{{node.database}}.{{ node.schema }}.{{ node.name }}`
     where false
   {% else %}
     {% if node.columns %}
@@ -101,10 +101,10 @@
   ) %}
   {% if source_relation | length > 0 %}
     {%- set source_sql -%}
-      select * from {{node.database}}.{{ node.schema }}.{{ node.name }} where false
+      select * from `{{node.database}}.{{ node.schema }}.{{ node.name }}` where false
     {%- endset -%}
     select {{ dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(source_sql)) }}
-    from {{node.database}}.{{ node.schema }}.{{ node.name }}
+    from `{{node.database}}.{{ node.schema }}.{{ node.name }}`
     where false
   {% else %}
     {% if node.columns %}
@@ -127,10 +127,10 @@
   ) %}
   {% if source_relation | length > 0 %}
     {%- set source_sql -%}
-      select * from {{node.database}}.{{ node.schema }}.{{ node.name }} where false
+      select * from `{{node.database}}.{{ node.schema }}.{{ node.name }}` where false
     {%- endset -%}
     select {{ dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(source_sql)) }}
-    from {{node.database}}.{{ node.schema }}.{{ node.name }}
+    from `{{node.database}}.{{ node.schema }}.{{ node.name }}`
     where false
   {% else %}
     {% if node.config and node.config.column_types %}

--- a/macros/test_helpers.sql
+++ b/macros/test_helpers.sql
@@ -14,7 +14,7 @@
 {% endmacro %}
 
 {% macro quote_and_join_columns(columns) %}
-  {% set columns = dbt_unit_testing.map(columns, dbt_unit_testing.quote_column_name) | join(",") %}
+  {% set columns = dbt_unit_testing.map(columns, dbt_unit_testing.quote_identifier) | join(",") %}
   {{ return (columns) }}
 {% endmacro %}
 

--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -20,7 +20,7 @@
 
 {% macro ref(model_name) %}
   {%- if 'unit-test' in config.get('tags') -%}
-      {{model_name}}
+      {{ dbt_unit_testing.quote_identifier(model_name) }}
   {%- else -%}
       {{ return (builtins.ref(model_name)) }}
   {%- endif -%}
@@ -28,7 +28,7 @@
 
 {% macro source(source, model_name) %}
   {%- if 'unit-test' in config.get('tags') -%}
-      {{model_name}}
+      {{ dbt_unit_testing.quote_identifier(model_name) }}
   {%- else -%}
       {{ return (builtins.source(source, model_name)) }}
   {%- endif -%}
@@ -69,7 +69,7 @@
     {% set extra_columns = dbt_unit_testing.extract_columns_difference(model_columns, input_columns) %}
 
     {%- set input_sql_with_all_columns -%}
-      select * from ({{input_values_sql}}) as {{model_name}}_tmp_1
+      select * from ({{input_values_sql}}) as {{ dbt_unit_testing.quote_identifier(model_name ~ '_tmp_1')}}
 
       {% if extra_columns %}
         {% if mocking_strategy.simplified %}
@@ -77,11 +77,11 @@
           {% for c in extra_columns %}
             {% set null_extra_columns = null_extra_columns.append("null as " ~ c) %}
           {% endfor %}
-          left join (select {{ null_extra_columns | join (",")}}) as {{model_name}}_tmp_3 on false
+          left join (select {{ null_extra_columns | join (",")}}) as {{ dbt_unit_testing.quote_identifier(model_name ~ '_tmp_3') }} on false
         {% else %}
           {% set simple_node_sql = dbt_unit_testing.build_node_sql(model_node, {"fetch_mode": 'DATABASE' if mocking_strategy.database else 'RAW' }) %}
             left join (select {{ extra_columns | join (",")}}
-                      from ({{ simple_node_sql }}) as {{model_name}}_tmp_2) as {{model_name}}_tmp_3 on false
+                      from ({{ simple_node_sql }}) as {{ dbt_unit_testing.quote_identifier(model_name ~ '_tmp_2') }}) as {{ dbt_unit_testing.quote_identifier(model_name ~ '_tmp_3') }} on false
         {% endif %}
       {% endif %}
 


### PR DESCRIPTION
When database name contains a dash (-), BigQuery requires backticks around the name.