### PR TITLE
More efficient introspection of column names

### DIFF
--- a/integration-tests/models/sources/sources.yml
+++ b/integration-tests/models/sources/sources.yml
@@ -13,5 +13,7 @@ sources:
         columns:
           - name: example
             data_type: integer
+        quoting:
+          identifier: true
       - name: sample_source_name
         identifier: sample_source_identifier

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -90,7 +90,7 @@
 {% endmacro %}
 
 {% macro get_columns_sql(node, identifier, config_columns, error_message) %}
-  {% set columns = adapter.get_columns_in_relation(api.Relation.create(database=node.database, schema=node.schema, identifier=identifier)) %}
+  {% set columns = adapter.get_columns_in_relation(api.Relation.create(database=node.database, schema=node.schema, identifier=identifier, quote_policy=node.get('quoting', {}))) %}
   {% if columns | length > 0 %}
     select {{ dbt_unit_testing.quote_and_join_columns(columns | map(attribute='name') | list) }}
     from {{ dbt_unit_testing.node_to_sql(node.database, node.schema, identifier) }}

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -2,14 +2,6 @@
   {{ return(dbt_unit_testing.quote_identifier(database) ~ '.' ~ dbt_unit_testing.quote_identifier(schema) ~ '.' ~ dbt_unit_testing.quote_identifier(identifier))}}
 {% endmacro %}
 
-{% macro source_node_to_sql(node) %}
-  {{ return(dbt_unit_testing.node_to_sql(node.database, node.schema, node.identifier))}}
-{% endmacro %}
-
-{% macro model_node_to_sql(node) %}
-  {{ return(dbt_unit_testing.node_to_sql(node.database, node.schema, node.name))}}
-{% endmacro %}
-
 {% macro build_model_complete_sql(model_node, mocked_models, options) %}
   {% if execute %}
     {% set include_all_dependencies = options.get("include_all_dependencies", false) %}

--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -146,10 +146,9 @@
       {{ dbt_unit_testing.debug(test_query) }}
     {% endif %}
 
-    {% set r1 = run_query("select count(1) from (" ~ expectations_query ~ ") as t") %}
+    {% set r1 = run_query("select * FROM (select count(1) as expectation_count from (" ~ expectations_query ~ ")), (select count(1) as actual_count from (" ~ actual_query ~ "))") %}
     {% set expectations_row_count = r1.columns[0].values() | first %}
-    {% set r2 = run_query("select count(1) from (" ~ actual_query ~ ") as t") %}
-    {% set actual_row_count = r2.columns[0].values() | first %}
+    {% set actual_row_count = r1.columns[1].values() | first %}
 
     {% set results = run_query(test_query) %}
     {% set results_length = results.rows | length %}

--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -146,7 +146,7 @@
       {{ dbt_unit_testing.debug(test_query) }}
     {% endif %}
 
-    {% set r1 = run_query("select * FROM (select count(1) as expectation_count from (" ~ expectations_query ~ ")), (select count(1) as actual_count from (" ~ actual_query ~ "))") %}
+    {% set r1 = run_query("select * FROM (select count(1) as expectation_count from (" ~ expectations_query ~ ") as exp) as exp_count, (select count(1) as actual_count from (" ~ actual_query ~ ") as act) as act_count") %}
     {% set expectations_row_count = r1.columns[0].values() | first %}
     {% set actual_row_count = r1.columns[1].values() | first %}
 


### PR DESCRIPTION
We use dbt's native get_columns_in_relation to get column names.
This eliminates two SQL queries: one to determine if the table exists, and one
to retrieve the column names.
get_columns_in_relation seems much faster, at least for BigQuery.

Partially resolves #51 