### PR TITLE
Fix Only one SQL statement allowed for Athena model with semicolon

### DIFF
--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -34,7 +34,8 @@
         with
         {{ cte_dependencies | join(",\n") }}
       {%- endif -%}
-      select * from ({{ render(model_node.raw_sql) }}) as t
+      {% set sql_without_end_semicolon = modules.re.sub(';[\s\r\n]*$', '', render(model_node.raw_sql), 0, modules.re.M) %}
+      select * from ({{ sql_without_end_semicolon }}) as t
     {%- endset -%}
 
     {{ return (final_sql) }}
@@ -65,7 +66,8 @@
       {% if fetch_mode | upper == 'FULL' %}
         {{ dbt_unit_testing.build_model_complete_sql(node, {}, {"fetch_mode": 'RAW'}) }}
       {% elif fetch_mode | upper == 'RAW' %}
-        {{ render(node.raw_sql) }}
+        {% set sql_without_end_semicolon = modules.re.sub(';[\s\r\n]*$', '', render(node.raw_sql), 0, modules.re.M) %}
+        {{ sql_without_end_semicolon }}
       {% elif fetch_mode | upper == 'DATABASE' %}
         {{ dbt_unit_testing.fake_model_sql(node) }}
       {% else %}


### PR DESCRIPTION
DBT allows models to end with ; and it works well with it
Once running unit tests I have the following error:
  An error occurred (InvalidRequestException) when calling the StartQueryExecution operation: Only one sql statement is allowed. Got: -- /* {"app": "dbt", "dbt_version": "1.0.4", "profile_name": "analytics", "target_name": "dev", "node_id": "test.analytics.merged_applicants_ut"} */

After investigations the root cause was found in `;` at the end of select
This PR replaces trailing `;` from raw sql to fix this issue
Ideally it's better to do something like this in DBT itself, but it might be risky for another use-cases and adapters