### PR TITLE
Fix node identifiers if test is in a package

### DIFF
--- a/integration-tests-sub-package/dbt_project.yml
+++ b/integration-tests-sub-package/dbt_project.yml
@@ -1,0 +1,6 @@
+name: "dbt_unit_testing_sub_package"
+version: "0.1.0"
+config-version: 2
+
+model-paths: ["models"]
+test-paths: ["tests"]

--- a/integration-tests-sub-package/models/sources.yml
+++ b/integration-tests-sub-package/models/sources.yml
@@ -1,0 +1,10 @@
+version: 2
+
+sources:
+  - name: dbt_unit_testing
+    tables:
+      - name: sub_package_sample_source
+        columns:
+          - name: a
+            data_type: integer
+          - name: b

--- a/integration-tests-sub-package/models/sub_package_model_a.sql
+++ b/integration-tests-sub-package/models/sub_package_model_a.sql
@@ -1,0 +1,1 @@
+select 1 as a, 'b' as b 

--- a/integration-tests-sub-package/models/sub_package_model_b_references_a.sql
+++ b/integration-tests-sub-package/models/sub_package_model_b_references_a.sql
@@ -1,0 +1,3 @@
+select * from {{ dbt_unit_testing.ref('sub_package_model_a') }} where a >=1
+union all
+select * from {{ dbt_unit_testing.source('dbt_unit_testing', 'sub_package_sample_source' )}} where a >= 1

--- a/integration-tests-sub-package/packages.yml
+++ b/integration-tests-sub-package/packages.yml
@@ -1,0 +1,3 @@
+
+packages:
+  - local: ../

--- a/integration-tests-sub-package/tests/sub_package_model_b_references_a.sql
+++ b/integration-tests-sub-package/tests/sub_package_model_b_references_a.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        tags=['unit-test', 'bigquery', 'snowflake', 'postgres', 'subpack']
+    )
+}}
+
+{% call dbt_unit_testing.test('sub_package_model_b_references_a', 'sample test') %}
+  {% call dbt_unit_testing.mock_ref ('sub_package_model_a') %}
+    select 0 as a, 'a' as b
+    UNION ALL
+    select 1 as a, 'b' as b
+  {% endcall %}
+  {% call dbt_unit_testing.mock_source ('dbt_unit_testing', 'sub_package_sample_source') %}
+    select 2 as a, 'c' as b
+  {% endcall %}
+  {% call dbt_unit_testing.expect() %}
+    select 1 as a, 'b' as b
+    UNION ALL
+    select 2 as a, 'c' as b
+  {% endcall %}
+{% endcall %}
+ 

--- a/integration-tests/packages.yml
+++ b/integration-tests/packages.yml
@@ -1,3 +1,4 @@
 
 packages:
   - local: ../
+  - local: ../integration-tests-sub-package

--- a/macros/test_helpers.sql
+++ b/macros/test_helpers.sql
@@ -52,14 +52,15 @@
 {% endmacro %}
 
 {% macro model_node (model_name) %}
+  {% set package_name = model.package_name %}
   {% if execute %}
-    {% set node = graph.nodes["model." ~ project_name ~ "." ~ model_name] %}
+    {% set node = graph.nodes["model." ~ package_name ~ "." ~ model_name] %}
     {% if not node %}
-      {% set node = graph.nodes["snapshot." ~ project_name ~ "." ~ model_name] %}
+      {% set node = graph.nodes["snapshot." ~ package_name ~ "." ~ model_name] %}
       {% if not node %}
-        {% set node = graph.nodes["seed." ~ project_name ~ "." ~ model_name] %}
+        {% set node = graph.nodes["seed." ~ package_name ~ "." ~ model_name] %}
          {% if not node %}
-           {{ exceptions.raise_compiler_error("Node "  ~ project_name ~ "." ~ model_name ~ " not found.") }}
+           {{ exceptions.raise_compiler_error("Node "  ~ package_name ~ "." ~ model_name ~ " not found.") }}
          {% endif %}
       {% endif %}
     {% endif %}
@@ -69,7 +70,7 @@
 
 {% macro source_node (source_name, model_name) %}
   {% if execute %}
-    {{ return (graph.sources["source." ~ project_name ~ "." ~ source_name ~ "." ~ model_name]) }}
+    {{ return (graph.sources["source." ~ model.package_name ~ "." ~ source_name ~ "." ~ model_name]) }}
   {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
If a (sub)package with unit tests is imported from another (parent) project, the variable project_name will be that of the parent project. We should instead use model.package_name, which is the name of the subpackage containing the unit test.

Added a subpackage with a test to ensure that this works as expected.