### PR TITLE
Support sources with the same name in different schemas

### DIFF
--- a/integration-tests/models/model_union_multi_schema.sql
+++ b/integration-tests/models/model_union_multi_schema.sql
@@ -1,0 +1,3 @@
+select 'dbt_unit_testing' as from_schema, * from {{ dbt_unit_testing.source('dbt_unit_testing', 'multi_schema') }}
+union all
+select 'dbt_unit_testing_2' as from_schema, * from {{ dbt_unit_testing.source('dbt_unit_testing_2', 'multi_schema') }}

--- a/integration-tests/models/setup-existing-source/multi_schema_1.sql
+++ b/integration-tests/models/setup-existing-source/multi_schema_1.sql
@@ -1,0 +1,7 @@
+{{
+  config(
+    alias='multi_schema',
+    schema='dbt_unit_testing'
+  )
+}}
+select 'one' as name

--- a/integration-tests/models/setup-existing-source/multi_schema_2.sql
+++ b/integration-tests/models/setup-existing-source/multi_schema_2.sql
@@ -1,0 +1,7 @@
+{{
+  config(
+    alias='multi_schema',
+    schema='dbt_unit_testing_2'
+  )
+}}
+select 'two' as name

--- a/integration-tests/models/sources/sources.yml
+++ b/integration-tests/models/sources/sources.yml
@@ -17,3 +17,12 @@ sources:
           identifier: true
       - name: sample_source_name
         identifier: sample_source_identifier
+      - name: multi_schema
+        columns:
+          - name: name
+
+  - name: dbt_unit_testing_2
+    tables:
+      - name: multi_schema
+        columns:
+          - name: name

--- a/integration-tests/tests/unit/model_union_multi_schema.sql
+++ b/integration-tests/tests/unit/model_union_multi_schema.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        tags=['unit-test', 'bigquery', 'snowflake', 'postgres']
+    )
+}}
+
+{% call dbt_unit_testing.test('model_union_multi_schema', 'sample test') %}
+  {% call dbt_unit_testing.mock_source('dbt_unit_testing','multi_schema') %}
+    select 'ONE' as name
+  {% endcall %}
+
+  {% call dbt_unit_testing.mock_source('dbt_unit_testing_2','multi_schema') %}
+    select 'TWO' as name
+  {% endcall %}
+
+  {% call dbt_unit_testing.expect() %}
+    select 'dbt_unit_testing' as from_schema, 'ONE' as name
+    union all
+    select 'dbt_unit_testing_2' as from_schema, 'TWO' as name
+  {% endcall %}
+{% endcall %}

--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -37,7 +37,7 @@
 
 {% macro source(source, model_name) %}
   {%- if 'unit-test' in config.get('tags') -%}
-      {{ dbt_unit_testing.quote_identifier(model_name) }}
+      {{ dbt_unit_testing.quote_identifier(source ~ "__" ~ model_name) }}
   {%- else -%}
       {{ return (builtins.source(source, model_name)) }}
   {%- endif -%}
@@ -96,7 +96,13 @@
       {%- endif -%}
     {%- endset -%}
 
-    {% set input_as_json = '"' ~ model_name  ~ '": "' ~ dbt_unit_testing.sql_encode(input_sql_with_all_columns) ~ '",' %}
+    {%- if source_name == '' -%}
+      {%- set model_key = model_name -%}
+    {%- else -%}
+      {%- set model_key = [source_name, model_name]|join('__') -%}
+    {%- endif -%}
+
+    {% set input_as_json = '"' ~ model_key  ~ '": "' ~ dbt_unit_testing.sql_encode(input_sql_with_all_columns) ~ '",' %}
     {{ return (input_as_json) }}
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
This commit adjusts the way that source names are referenced
in dictionaries and CTEs to include the name of the source
with the "model" name.  This allows us to reference
source models that have the same name but live in different
schemas.