### PR TITLE
Support for same model names in sources and refs

### DIFF
--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -20,7 +20,11 @@
     {% set model_dependencies = dbt_unit_testing.build_model_dependencies(model_node, dependencies_to_exclude) %}
     {% for node_id in model_dependencies %}
       {% set node = dbt_unit_testing.node_by_id(node_id) %}
-      {% set node_schema_name = node.schema ~ "_" ~ node.name %}
+      {% if node.resource_type == "source" %}
+        {% set node_schema_name = node.schema ~ "_" ~ node.name %}
+      {% else %}
+        {% set node_schema_name = node.name %}
+      {% endif %}
       {% if node_schema_name in mocked_models_names %}
         {% set sql = mocked_models[node_schema_name] %}
       {% else %}
@@ -47,7 +51,11 @@
   {% set model_dependencies = [] %}
   {% for node_id in node.depends_on.nodes %}
     {% set node = dbt_unit_testing.node_by_id(node_id) %}
-    {% set node_schema_name = node.schema ~ "_" ~ node.name %}
+    {% if node.resource_type == "source" %}
+      {% set node_schema_name = node.schema ~ "_" ~ node.name %}
+    {% else %}
+      {% set node_schema_name = node.name %}
+    {% endif %}
     {% if node.resource_type in ('model','snapshot') and (models_names_to_exclude is none or node_schema_name not in models_names_to_exclude) %}
       {% set child_model_dependencies = dbt_unit_testing.build_model_dependencies(node) %}
       {% for dependency_node_id in child_model_dependencies %}

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -20,12 +20,13 @@
     {% set model_dependencies = dbt_unit_testing.build_model_dependencies(model_node, dependencies_to_exclude) %}
     {% for node_id in model_dependencies %}
       {% set node = dbt_unit_testing.node_by_id(node_id) %}
-      {% if node.name in mocked_models_names %}
-        {% set sql = mocked_models[node.name] %}
+      {% set node_schema_name = node.schema ~ "_" ~ node.name %}
+      {% if node_schema_name in mocked_models_names %}
+        {% set sql = mocked_models[node_schema_name] %}
       {% else %}
         {% set sql = dbt_unit_testing.build_node_sql(node, options) %}
       {% endif %}
-      {% set cte = dbt_unit_testing.quote_identifier(node.name) ~ " as (" ~ sql ~ ")" %}
+      {% set cte = dbt_unit_testing.quote_identifier(node_schema_name) ~ " as (" ~ sql ~ ")" %}
       {% set cte_dependencies = cte_dependencies.append(cte) %}
     {%- endfor -%}
 
@@ -46,7 +47,8 @@
   {% set model_dependencies = [] %}
   {% for node_id in node.depends_on.nodes %}
     {% set node = dbt_unit_testing.node_by_id(node_id) %}
-    {% if node.resource_type in ('model','snapshot') and (models_names_to_exclude is none or node.name not in models_names_to_exclude) %}
+    {% set node_schema_name = node.schema ~ "_" ~ node.name %}
+    {% if node.resource_type in ('model','snapshot') and (models_names_to_exclude is none or node_schema_name not in models_names_to_exclude) %}
       {% set child_model_dependencies = dbt_unit_testing.build_model_dependencies(node) %}
       {% for dependency_node_id in child_model_dependencies %}
         {{ model_dependencies.append(dependency_node_id) }}

--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -20,7 +20,7 @@
 
 {% macro ref(model_name) %}
   {%- if 'unit-test' in config.get('tags') -%}
-      {{ dbt_unit_testing.quote_identifier(("" ~ builtins.ref(model_name)).replace('.', '_')) }}
+      {{ dbt_unit_testing.quote_identifier(model_name) }}
   {%- else -%}
       {{ return (builtins.ref(model_name)) }}
   {%- endif -%}
@@ -47,6 +47,7 @@
 {% endmacro %}
 
 {% macro mock_ref(model_name, options={}) %}
+  
     {{ dbt_unit_testing.mock_input(model_name, '', caller(), options) }}
 {% endmacro %}
 
@@ -60,7 +61,11 @@
 
     {% set input_values_sql = dbt_unit_testing.build_input_values_sql(input_values, options) %}
     {% set model_node = dbt_unit_testing.graph_node(source_name, model_name_initial) %}
-    {% set model_name = model_node.schema ~ "_" ~ model_name_initial %}
+    {% if model_node.resource_type == "source" %}
+      {% set model_name = model_node.schema ~ "_" ~ model_name_initial %}
+    {% else %}
+      {% set model_name = model_name_initial %}
+    {% endif %}
 
     {% set options = {"fetch_mode": 'DATABASE' if mocking_strategy.database else 'FULL' } %}
     {% set full_node_sql = dbt_unit_testing.build_node_sql(model_node, options) %}

--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -20,7 +20,7 @@
 
 {% macro ref(model_name) %}
   {%- if 'unit-test' in config.get('tags') -%}
-      {{ dbt_unit_testing.quote_identifier(model_name) }}
+      {{ dbt_unit_testing.quote_identifier(("" ~ builtins.ref(model_name)).replace('.', '_')) }}
   {%- else -%}
       {{ return (builtins.ref(model_name)) }}
   {%- endif -%}
@@ -28,7 +28,7 @@
 
 {% macro source(source, model_name) %}
   {%- if 'unit-test' in config.get('tags') -%}
-      {{ dbt_unit_testing.quote_identifier(model_name) }}
+      {{ dbt_unit_testing.quote_identifier(("" ~ builtins.source(source, model_name)).replace('.', '_')) }}
   {%- else -%}
       {{ return (builtins.source(source, model_name)) }}
   {%- endif -%}
@@ -54,12 +54,13 @@
     {{ dbt_unit_testing.mock_input(model_name, source_name, caller(), options) }}
 {% endmacro %}
 
-{% macro mock_input(model_name, source_name, input_values, options) %}
+{% macro mock_input(model_name_initial, source_name, input_values, options) %}
   {% if execute %}
     {% set mocking_strategy = dbt_unit_testing.get_mocking_strategy(options) %}
 
     {% set input_values_sql = dbt_unit_testing.build_input_values_sql(input_values, options) %}
-    {% set model_node = dbt_unit_testing.graph_node(source_name, model_name) %}
+    {% set model_node = dbt_unit_testing.graph_node(source_name, model_name_initial) %}
+    {% set model_name = model_node.schema ~ "_" ~ model_name_initial %}
 
     {% set options = {"fetch_mode": 'DATABASE' if mocking_strategy.database else 'FULL' } %}
     {% set full_node_sql = dbt_unit_testing.build_node_sql(model_node, options) %}


### PR DESCRIPTION
**Issue:** Once I have a same name in different schemas and one schema added to dbt as source and another as ref models such 
tests will not execute due to duplicate names in generated SQL  
**Suggested fix:** add schema name to the source cte in generated SQL
__Notes:__ Initially I made the same for "ref" ctes, but ended up in a poor dev experience having to specify multiple "--depends_on ref()" in the test file comments to let dbt correctly resolve dependencies