### PR TITLE
Add ability to sort failed outputs by primary key for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,9 +275,9 @@ Note: Strategy names are case insensitive
 
 Good test feedback is what allows us to be productive when developing unit tests and developing our models.
 The test macro provides visual feedback when a test fails showing what went wrong by comparing the lines of the expectations with the actuals.
-To make the feedback even more readable you can provide `primary_key` in parameters specying the field to sort by:  
+To make the feedback even more readable you can provide `output_sort_field` in parameters specying the field to sort by:  
 ```jinja
-{% call dbt_unit_testing.test('some_model', 'smoke test', {"primary_key": "business_id"}) %}
+{% call dbt_unit_testing.test('some_model', 'smoke test', {"output_sort_field": "business_id"}) %}
 
   ...
   

--- a/README.md
+++ b/README.md
@@ -275,6 +275,15 @@ Note: Strategy names are case insensitive
 
 Good test feedback is what allows us to be productive when developing unit tests and developing our models.
 The test macro provides visual feedback when a test fails showing what went wrong by comparing the lines of the expectations with the actuals.
+To make the feedback even more readable you can provide `primary_key` in parameters specying the field to sort by:  
+```jinja
+{% call dbt_unit_testing.test('some_model', 'smoke test', {"primary_key": "business_id"}) %}
+
+  ...
+  
+{% endcall %}
+```
+The result will be displayed the way to conveniently compare 2 adjacent lines  
 
 ##### Example
 

--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -149,15 +149,13 @@
     select '-' as diff, {{columns}} from expectations
     {{ dbt_utils.except() }}
     select '-' as diff, {{columns}} from actual)
-
-    {% if options.get("primary_key", '') | length > 0 %}
-    select * from ( 
-    {% endif %}
-      select * from extra_entries
-      UNION ALL
-      select * from missing_entries
-    {% if options.get("primary_key", '') | length > 0 %}
-    ) order by {{options.get("primary_key", '')}}
+    
+    select * from extra_entries
+    UNION ALL
+    select * from missing_entries
+    {% set sort_field = options.get("output_sort_field") %}
+    {% if sort_field %}
+    ORDER BY {{ sort_field }}
     {% endif %}
   {%- endset -%}
 

--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -150,9 +150,15 @@
     {{ dbt_utils.except() }}
     select '-' as diff, {{columns}} from actual)
 
-    select * from extra_entries
-    UNION ALL
-    select * from missing_entries
+    {% if options.get("primary_key", '') | length > 0 %}
+    select * from ( 
+    {% endif %}
+      select * from extra_entries
+      UNION ALL
+      select * from missing_entries
+    {% if options.get("primary_key", '') | length > 0 %}
+    ) order by {{options.get("primary_key", '')}}
+    {% endif %}
   {%- endset -%}
 
   {% if execute %}


### PR DESCRIPTION
In case of multiple lines of difference it's handy to order them by some "primary key" and compare 2 adjacent lines
Adding this optional parameter to the test
If you like the idea will add a note to README as well