### PR TITLE
Mock columns insensitive 

### DIFF
--- a/integration-tests/models/model_references_model_with_upper_column_name.sql
+++ b/integration-tests/models/model_references_model_with_upper_column_name.sql
@@ -1,0 +1,1 @@
+select * from {{ dbt_unit_testing.ref('model_with_upper_column_name') }}

--- a/integration-tests/models/model_with_upper_column_name.sql
+++ b/integration-tests/models/model_with_upper_column_name.sql
@@ -1,0 +1,1 @@
+select *, 1 as "UPPER_CASE_COLUMN" from {{ dbt_unit_testing.ref('model_a') }} where a >=1

--- a/integration-tests/tests/unit/upper_column_names_mocking.sql
+++ b/integration-tests/tests/unit/upper_column_names_mocking.sql
@@ -1,0 +1,26 @@
+{{
+    config(
+        tags=['unit-test', 'snowflake', 'postgres']
+    )
+}}
+
+{% call dbt_unit_testing.test('model_references_model_with_upper_column_name', 'should work') %}
+  {% call dbt_unit_testing.mock_ref ('model_with_upper_column_name') %}
+    select 1 as a, 'b' as b, 1 as "UPPER_CASE_COLUMN"
+  {% endcall %}
+  {% call dbt_unit_testing.expect() %}
+    select 1 as a, 'b' as b, 1 as "UPPER_CASE_COLUMN"
+  {% endcall %}
+{% endcall %}
+
+UNION ALL
+
+{% call dbt_unit_testing.test('model_references_model_with_upper_column_name', 'should work case insensitive') %}
+  {% call dbt_unit_testing.mock_ref ('model_with_upper_column_name') %}
+    select 1 as a, 'b' as b, 1 as upper_case_column
+  {% endcall %}
+  {% call dbt_unit_testing.expect() %}
+    select 1 as a, 'b' as b, 1 as upper_case_column
+  {% endcall %}
+{% endcall %}
+ 

--- a/macros/test_helpers.sql
+++ b/macros/test_helpers.sql
@@ -9,7 +9,7 @@
 {% endmacro %}
 
 {% macro extract_columns_difference(cl1, cl2) %}
-  {% set columns = cl1 | list | reject('in', cl2) | list %}
+  {% set columns = cl1 | map('lower') | list | reject('in', cl2 | map('lower') | list) | list %}
   {{ return(columns) }}
 {% endmacro %}
 


### PR DESCRIPTION
When comparing columns to mock columns which are not present on the mocks, the comparison should be case insensitive. 