### PR TITLE
Remove warning: the `except` macro is now provided in dbt Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add the following to packages.yml
 ```yaml
 packages:
   - git: "https://github.com/EqualExperts/dbt-unit-testing"
-    revision: v0.2.0
+    revision: v0.2.3
 ```
 
 [read the docs](https://docs.getdbt.com/docs/package-management) for more information on installing packages.

--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -86,12 +86,12 @@
 
     extra_entries as (
     select '+' as diff, count, {{columns}} from actual
-    {{ dbt_utils.except() }}
+    {{ except() }}
     select '+' as diff, count, {{columns}} from expectations),
 
     missing_entries as (
     select '-' as diff, count, {{columns}} from expectations
-    {{ dbt_utils.except() }}
+    {{ except() }}
     select '-' as diff, count, {{columns}} from actual)
     
     select * from extra_entries


### PR DESCRIPTION
Removing dbt waring:
```
Warning: the `except` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `except` (no prefix) instead. The ga_snowflake.test_my_first_dbt_model model triggered this warning.
```