### PR TITLE
FEAT - add a column alias to the final test query, to allow storing dbt test failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv/
 .venv/
 integration-tests/ci/.user.yml
 tmp
+.idea

--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -18,7 +18,7 @@
       {{ dbt_unit_testing.show_test_report(test_configuration, test_report) }}
     {% endif %}
     
-    select 1 from (select 1) as t where {{ not test_report.succeeded }}
+    select 1 as a from (select 1) as t where {{ not test_report.succeeded }}
   {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
We are using BigQuery and the tests were failing with the following error:

```
13:15:19  Database Error in test unittest_jaffle (tests/unittest_jaffle.sql)
13:15:19    CREATE TABLE columns must be named, but column 1 has no name at [9:6]
```

After back engineering we noticed that the test report query was not naming the column. It is a small change but mandatory for BigQuery users.