### PR TITLE
Interpolate model_name variable in the show_test_report macro

### DIFF
--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -117,7 +117,7 @@
   {% set model_name = test_configuration.model_name %}
   {% set test_description = test_configuration.description | default('(no description)') %}
 
-  {{ dbt_unit_testing.println('{RED}MODEL: {YELLOW}model_name') }}
+  {{ dbt_unit_testing.println('{RED}MODEL: {YELLOW}' ~ model_name) }}
   {{ dbt_unit_testing.println('{RED}TEST:  {YELLOW}' ~ test_description) }}
   {% if test_report.expectations_row_count != test_report.actual_row_count %}
     {{ dbt_unit_testing.println('{RED}ERROR: {YELLOW}Number of Rows do not match! (Expected: ' ~ test_report.expectations_row_count ~ ', Actual: ' ~ test_report.actual_row_count ~ ')') }}


### PR DESCRIPTION
I noticed that we had `MODEL: model_name` show inside of our test output instead of the `MODEL: <actual-name-we-passed-in>` value.

Based on a little bit of digging, it looks like the `model_name` variable wasn't getting interpolated correctly, so this addresses that.