### PR TITLE
Make it possible to configure postgres target host while maintaining default for CI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: python:3.8.5
     environment:
       - GOOGLE_CLOUD_PROJECT
+      - POSTGRES_HOST=postgres
     entrypoint: "${RUN_SCRIPT} ${TARGET}"
     working_dir: /repo
     volumes:

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -2,6 +2,6 @@ TARGETS = bigquery
 .PHONY : test
 
 test: export TARGET = $(target)
-test: export RUN_SCRIPT = /repo/run_test.sh
+test: export RUN_SCRIPT = /repo/run-all-integration-tests.sh
 test:
 	docker-compose -f ../docker-compose.yml up --abort-on-container-exit

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -2,22 +2,7 @@
 
 To run the integration tests on your local machine using postgres, you can do the following:
 
-- Change the ci/profiles.yml
-
-```diff
-   postgres:
-      type: postgres
--     host: localhost
-+     host: postgres
-      user: postgres
-      pass: postgres
-      port: 5432
-      schema: dbt_unit_testing
-      dbname: postgres
-      threads: 1
-```
-
-- Run the following command inside the integration_tests folder
+Run the following command inside the `integration-tests` folder:
 
 ```bash
 make TARGET=postgres

--- a/integration-tests/ci/profiles.yml
+++ b/integration-tests/ci/profiles.yml
@@ -10,7 +10,7 @@ integration_tests:
     
     postgres:
       type: postgres
-      host: localhost
+      host: "{{ env_var('POSTGRES_HOST', 'localhost') }}"
       user: postgres
       pass: postgres
       port: 5432

--- a/jaffle-shop/README.md
+++ b/jaffle-shop/README.md
@@ -29,20 +29,7 @@ If you want to run the tests on your machine and play with the examples:
 
 1. You need to have docker.
 2. Clone this repository.
-3. Change jaffle_shop [profiles.yml](./ci/profiles.yml)
-```diff
-   postgres:
-      type: postgres
--     host: localhost
-+     host: postgres
-      user: postgres
-      pass: postgres
-      port: 5432
-      schema: dbt_unit_testing
-      dbname: postgres
-      threads: 1
+3. Use make to run
 ```
-4. Use make to run
-```
-> make run
+make
 ```

--- a/jaffle-shop/ci/profiles.yml
+++ b/jaffle-shop/ci/profiles.yml
@@ -3,7 +3,7 @@ jaffle_shop:
   outputs:
     postgres:
       type: postgres
-      host: localhost
+      host: "{{ env_var('POSTGRES_HOST', 'localhost') }}"
       user: postgres
       pass: postgres
       port: 5432


### PR DESCRIPTION
In running the tests locally I noticed that the profiles were hardcoded to `localhost` for CI purposes, however making them configurable like this allows for an override when you're trying to run the tests inside of local docker-compose setup, where the Postgres service container will by default be available under `postgres` hostname instead `localhost`.

This seemed like a more reasonable solution instead of messing with the docker-compose networking setup.

EDIT: This also updates the `README`s to better reflect the workflow and updates an incorrect RUN_SCRIPT value for `integration-tests`.