### PR TITLE
Clickhouse feature; getting columns from source; fix field name and table path

### DIFF
--- a/macros/mock_builders.sql
+++ b/macros/mock_builders.sql
@@ -53,7 +53,8 @@
   {% set model_columns = dbt_unit_testing.get_from_cache("COLUMNS", model_node.name) %}
   {% if not model_columns %}
     {% set model_sql = dbt_unit_testing.build_node_sql(model_node, complete=true, use_database_models=options.use_database_models) %}
-    {% set model_columns = dbt_unit_testing.extract_columns_list(model_sql) %}
+--     {% set model_columns = dbt_unit_testing.extract_columns_list(model_sql) %}
+    {% set model_columns = model_node.columns.values() | map(attribute='name') | list %}
     {{ dbt_unit_testing.cache("COLUMNS", model_node.name, model_columns)}}
   {% else %}
     {{ dbt_unit_testing.verbose("CACHE HIT for " ~ model_node.name ~ " COLUMNS") }}

--- a/macros/mock_builders.sql
+++ b/macros/mock_builders.sql
@@ -53,8 +53,9 @@
   {% set model_columns = dbt_unit_testing.get_from_cache("COLUMNS", model_node.name) %}
   {% if not model_columns %}
     {% set model_sql = dbt_unit_testing.build_node_sql(model_node, complete=true, use_database_models=options.use_database_models) %}
---     {% set model_columns = dbt_unit_testing.extract_columns_list(model_sql) %}
-    {% set model_columns = model_node.columns.values() | map(attribute='name') | list %}
+    {% set sql_model_columns = dbt_unit_testing.extract_columns_list(model_sql) %}
+    {% set source_model_columns = model_node.columns.values() | map(attribute='name') | list %}
+    {% set model_columns = (sql_model_columns + source_model_columns) | unique | list %}
     {{ dbt_unit_testing.cache("COLUMNS", model_node.name, model_columns)}}
   {% else %}
     {{ dbt_unit_testing.verbose("CACHE HIT for " ~ model_node.name ~ " COLUMNS") }}

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -86,7 +86,7 @@
       {% set name = node.name %}
     {%- endif %}
 
-    select * from {{ dbt_unit_testing.quote_identifier(node.database) ~ '.' ~ dbt_unit_testing.quote_identifier(node.schema) ~ '.' ~ dbt_unit_testing.quote_identifier(name) }} where false
+    select * from {{ dbt_unit_testing.quote_identifier(node.database) ~ '.' ~ dbt_unit_testing.quote_identifier(name) }} where false
   {%- else -%}
     {% if complete %}
       {{ dbt_unit_testing.build_model_complete_sql(node) }}

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -23,7 +23,9 @@
     {%- endif -%}
     {{ "\n" }}
     select * from ({{ dbt_unit_testing.render_node(model_node) }} {{ "\n" }} ) as t
-    SETTINGS join_algorithm='hash'
+    {% if adapter.type() == 'clickhouse' %}
+      SETTINGS join_algorithm='hash'
+    {% endif %}
   {%- endset -%}
 
   {% do return(model_complete_sql) %}
@@ -86,7 +88,13 @@
       {% set name = node.name %}
     {%- endif %}
 
-    select * from {{ dbt_unit_testing.quote_identifier(node.database) ~ '.' ~ dbt_unit_testing.quote_identifier(name) }} where false
+    {%- if node.database is none %}
+      {% set table_path = dbt_unit_testing.quote_identifier(node.schema) ~ '.' ~ dbt_unit_testing.quote_identifier(name) %}
+    {%- else %}
+      {% set table_path = dbt_unit_testing.quote_identifier(node.database) ~ '.' ~ dbt_unit_testing.quote_identifier(node.schema) ~ '.' ~ dbt_unit_testing.quote_identifier(name) %}
+    {%- endif %}
+
+    select * from {{ table_path }} where false
   {%- else -%}
     {% if complete %}
       {{ dbt_unit_testing.build_model_complete_sql(node) }}

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -23,6 +23,7 @@
     {%- endif -%}
     {{ "\n" }}
     select * from ({{ dbt_unit_testing.render_node(model_node) }} {{ "\n" }} ) as t
+    SETTINGS join_algorithm='hash'
   {%- endset -%}
 
   {% do return(model_complete_sql) %}

--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -3,21 +3,21 @@
 
   {% if execute %}
     {% set test_configuration = {
-      "model_name": model_name, 
-      "description": test_description, 
-      "options": dbt_unit_testing.merge_configs([options])} 
+      "model_name": model_name,
+      "description": test_description,
+      "options": dbt_unit_testing.merge_configs([options])}
     %}
     {% set mocks_and_expectations_json_str = caller() %}
 
     {{ dbt_unit_testing.verbose("CONFIG: " ~ test_configuration) }}
-    
+
     {% do test_configuration.update (dbt_unit_testing.build_mocks_and_expectations(test_configuration, mocks_and_expectations_json_str)) %}
     {% set test_report = dbt_unit_testing.build_test_report(test_configuration) %}
 
     {% if not test_report.succeeded %}
       {{ dbt_unit_testing.show_test_report(test_configuration, test_report) }}
     {% endif %}
-    
+
     select 1 as a from (select 1) as t where {{ not test_report.succeeded }}
   {% endif %}
 {% endmacro %}
@@ -69,11 +69,11 @@
   {% set columns = dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(expectations.input_values)) %}
 
   {%- set actual_query -%}
-    select count(1) as count, {{columns}} from ( {{ model_complete_sql }} ) as s group by {{ columns }}
+    select count(1) as count123, {{columns}} from ( {{ model_complete_sql }} ) as s group by {{ columns }}
   {% endset %}
 
   {%- set expectations_query -%}
-    select count(1) as count, {{columns}} from ({{ expectations.input_values }}) as s group by {{ columns }}
+    select count(1) as count123, {{columns}} from ({{ expectations.input_values }}) as s group by {{ columns }}
   {% endset %}
 
   {%- set test_query -%}
@@ -85,15 +85,15 @@
     ),
 
     extra_entries as (
-    select '+' as diff, count, {{columns}} from actual
+    select '+' as diff, count123, {{columns}} from actual
     {{ except() }}
-    select '+' as diff, count, {{columns}} from expectations),
+    select '+' as diff, count123, {{columns}} from expectations),
 
     missing_entries as (
-    select '-' as diff, count, {{columns}} from expectations
+    select '-' as diff, count123, {{columns}} from expectations
     {{ except() }}
-    select '-' as diff, count, {{columns}} from actual)
-    
+    select '-' as diff, count123, {{columns}} from actual)
+
     select * from extra_entries
     UNION ALL
     select * from missing_entries
@@ -136,7 +136,7 @@
   {% set test_query = test_queries.test_query %}
 
   {%- set count_query -%}
-    select * FROM 
+    select * FROM
       (select count(1) as expectation_count from (
         {{ expectations_query }}
       ) as exp) as exp_count,

--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -69,11 +69,11 @@
   {% set columns = dbt_unit_testing.quote_and_join_columns(dbt_unit_testing.extract_columns_list(expectations.input_values)) %}
 
   {%- set actual_query -%}
-    select count(1) as count123, {{columns}} from ( {{ model_complete_sql }} ) as s group by {{ columns }}
+    select count(1) as count_stat, {{columns}} from ( {{ model_complete_sql }} ) as s group by {{ columns }}
   {% endset %}
 
   {%- set expectations_query -%}
-    select count(1) as count123, {{columns}} from ({{ expectations.input_values }}) as s group by {{ columns }}
+    select count(1) as count_stat, {{columns}} from ({{ expectations.input_values }}) as s group by {{ columns }}
   {% endset %}
 
   {%- set test_query -%}
@@ -85,14 +85,14 @@
     ),
 
     extra_entries as (
-    select '+' as diff, count123, {{columns}} from actual
+    select '+' as diff, count_stat, {{columns}} from actual
     {{ except() }}
-    select '+' as diff, count123, {{columns}} from expectations),
+    select '+' as diff, count_stat, {{columns}} from expectations),
 
     missing_entries as (
-    select '-' as diff, count123, {{columns}} from expectations
+    select '-' as diff, count_stat, {{columns}} from expectations
     {{ except() }}
-    select '-' as diff, count123, {{columns}} from actual)
+    select '-' as diff, count_stat, {{columns}} from actual)
 
     select * from extra_entries
     UNION ALL


### PR DESCRIPTION
Fixes:
- getting column names from query sometimes not work, so we can get it from source.yml table description
- for clickhouse join is not working so we need to point out join algorithm
- in different databases you have only schema and no database name in table path, so node.database can be empty
- count is popular word and it can be a field in initial query, so we need to use more specifit name