### PR TITLE
Fix bug where the running_unit_test() macro raising a "None is not iterable" exception if not run within a model

### DIFF
--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -177,7 +177,7 @@
 {% endmacro %}
 
 {% macro running_unit_test() %}
-  {{ return ('unit-test' in config.get('tags')) }}
+  {{ return (config.get('tags') and 'unit-test' in config.get('tags')) }}
 {% endmacro %}
 
 {% macro ref_tested_model(model_name) %}


### PR DESCRIPTION
Resolves: https://github.com/EqualExperts/dbt-unit-testing/issues/151