### PR TITLE
FEAT: make sql_from_csv externally callable

### DIFF
--- a/macros/input_parsing.sql
+++ b/macros/input_parsing.sql
@@ -9,7 +9,7 @@
 {% endmacro %}
 
 {% macro sql_from_csv(options={}) %}
-  {{ return (sql_from_csv_input(caller(), options)) }}
+  {{ return (dbt_unit_testing.sql_from_csv_input(caller(), options)) }}
 {% endmacro %}
 
 {% macro sql_from_csv_input(csv_table, options) %}


### PR DESCRIPTION
The util function sql_from_csv is very useful for external use but failed when called externally for its local reference to sql_from_csv_input. The reference is made global.