### PR TITLE
Add databricks quote identifier adapter

### DIFF
--- a/macros/utils.sql
+++ b/macros/utils.sql
@@ -191,14 +191,6 @@
     {% endif %}
 {%- endmacro %}
 
-{% macro spark__quote_identifier(identifier) %}
-    {% if identifier.startswith('`') %}
-      {{ return(identifier) }}
-    {% else %}
-      {{ return('`' ~ identifier ~ '`') }}
-    {% endif %}
-{% endmacro %}
-
 {% macro bigquery__quote_identifier(identifier) %}
     {% if identifier.startswith('`') %}
       {{ return(identifier) }}
@@ -207,11 +199,27 @@
     {% endif %}
 {% endmacro %}
 
+{% macro databricks__quote_identifier(identifier) %}
+    {% if identifier.startswith('`') %}
+      {{ return(identifier) }}
+    {% else %}
+      {{ return('`' ~ identifier ~ '`') }}
+    {% endif %}
+{% endmacro %}
+  
 {% macro snowflake__quote_identifier(identifier) %}
     {% if identifier.startswith('"') %}
       {{ return(identifier) }}
     {% else %}
       {{ return('"' ~ identifier | upper ~ '"') }}
+    {% endif %}
+{% endmacro %}
+
+{% macro spark__quote_identifier(identifier) %}
+    {% if identifier.startswith('`') %}
+      {{ return(identifier) }}
+    {% else %}
+      {{ return('`' ~ identifier ~ '`') }}
     {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
Although we don't support officially databricks, as per request [here](https://github.com/EqualExperts/dbt-unit-testing/issues/209) we are adding the adapter function.