### PR TITLE
`test` macro: set `model_node_being_tested` before `caller()` instead of after

### DIFF
--- a/macros/tests.sql
+++ b/macros/tests.sql
@@ -4,10 +4,10 @@
   {% if execute %}
     {% if flags.WHICH in ('test', 'build') %}
       {{ dbt_unit_testing.set_test_context("is_incremental_should_be_true_for_this_model", "") }}
-      {% set mocks_and_expectations_json_str = caller() %}
       {% set model_version = kwargs["version"] | default(kwargs["v"]) | default(none) %}
       {% set model_node = {"package_name": model.package_name, "name": model_name, "version": model_version} %}
       {{ dbt_unit_testing.set_test_context("model_node_being_tested", model_node) }}
+      {% set mocks_and_expectations_json_str = caller() %}
       {% set test_configuration, test_queries = dbt_unit_testing.build_configuration_and_test_queries(model_node, test_description, options, mocks_and_expectations_json_str) %}
       {% set test_report = dbt_unit_testing.build_test_report(test_configuration, test_queries) %}
 


### PR DESCRIPTION
Part of the use case for #210 was to be able to build up queries in the `dbt_unit_testing.test()` block using model metadata, e.g. the columns list.

I am noticing that sometimes `model_node_being_tested` is not set at the execution time of `caller()`. For some of our models it is fine, for some it isn't. I am not sure what the difference is.

Was there a reason that the context is only being set after `caller()`? Is there any harm in doing it earlier like proposed in this PR?